### PR TITLE
Support additional printing columns in MCC

### DIFF
--- a/api/v1alpha1/managementclusterconfiguration_types.go
+++ b/api/v1alpha1/managementclusterconfiguration_types.go
@@ -168,6 +168,7 @@ type FailureStatus struct {
 // +kubebuilder:printcolumn:name="Prefix",type="string",JSONPath=".spec.destination.naming.prefix",description=""
 // +kubebuilder:printcolumn:name="Suffix",type="string",JSONPath=".spec.destination.naming.suffix",description=""
 // +kubebuilder:printcolumn:name="UseSeparator",type="boolean",JSONPath=".spec.destination.naming.useSeparator",description=""
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""
 type ManagementClusterConfiguration struct {

--- a/api/v1alpha1/managementclusterconfiguration_types.go
+++ b/api/v1alpha1/managementclusterconfiguration_types.go
@@ -163,6 +163,13 @@ type FailureStatus struct {
 // +kubebuilder:resource:shortName=mcc
 
 // ManagementClusterConfiguration is the Schema for the managementclusterconfigurations API.
+// +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".spec.configuration.cluster.name",description=""
+// +kubebuilder:printcolumn:name="Destination",type="string",JSONPath=".spec.destination.namespace",description=""
+// +kubebuilder:printcolumn:name="Prefix",type="string",JSONPath=".spec.destination.naming.prefix",description=""
+// +kubebuilder:printcolumn:name="Suffix",type="string",JSONPath=".spec.destination.naming.suffix",description=""
+// +kubebuilder:printcolumn:name="UseSeparator",type="boolean",JSONPath=".spec.destination.naming.useSeparator",description=""
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""
 type ManagementClusterConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/konfigure.giantswarm.io_managementclusterconfigurations.yaml
+++ b/config/crd/bases/konfigure.giantswarm.io_managementclusterconfigurations.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .spec.destination.naming.useSeparator
       name: UseSeparator
       type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string

--- a/config/crd/bases/konfigure.giantswarm.io_managementclusterconfigurations.yaml
+++ b/config/crd/bases/konfigure.giantswarm.io_managementclusterconfigurations.yaml
@@ -16,7 +16,29 @@ spec:
     singular: managementclusterconfiguration
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.configuration.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.destination.namespace
+      name: Destination
+      type: string
+    - jsonPath: .spec.destination.naming.prefix
+      name: Prefix
+      type: string
+    - jsonPath: .spec.destination.naming.suffix
+      name: Suffix
+      type: string
+    - jsonPath: .spec.destination.naming.useSeparator
+      name: UseSeparator
+      type: boolean
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ManagementClusterConfiguration is the Schema for the managementclusterconfigurations


### PR DESCRIPTION
Original output:

```text
NAMESPACE        NAME         AGE
org-example      example-1    15d
```

After change:

```text
NAMESPACE        NAME           CLUSTER   DESTINATION      PREFIX   SUFFIX   USESEPARATOR   AGE     READY   STATUS
org-example      example-1      golem     org-example               ex1      true           15d     True    Applied revision: 4361f91d4af7593c53bda86b149966a72f8092fb
```